### PR TITLE
bugfix: id setter was bypassed

### DIFF
--- a/textures.coffee
+++ b/textures.coffee
@@ -269,7 +269,7 @@ umd ->
     d = ""
     shapeRendering = "auto"
     fill = "transparent"
-    id = undefined
+    id = rand()
 
     # Contributions with custom paths are welcome,
     # for example have a look at the "hexagons" path below
@@ -307,7 +307,6 @@ umd ->
 
     paths = (sel) ->
       path = svgPath d
-      id = rand()
       g = sel.append "defs"
         .append "pattern"
         .attr "id", id


### PR DESCRIPTION
I hit a bug on the library when trying to force an `id` on a path. It works for lines and circles so I took the same approach.